### PR TITLE
Added new options when end can't be reached

### DIFF
--- a/AStar/Options/PathFinderOptions.cs
+++ b/AStar/Options/PathFinderOptions.cs
@@ -12,6 +12,8 @@ namespace AStar.Options
 
         public int SearchLimit { get; set; }
 
+        public bool ClosestNodeWhenCantReach { get; set; }
+
         public PathFinderOptions()
         {
             HeuristicFormula = HeuristicFormula.Manhattan;

--- a/AStar/PathFinder.cs
+++ b/AStar/PathFinder.cs
@@ -36,6 +36,8 @@ namespace AStar
         {
             var nodesVisited = 0;
             IModelAGraph<PathFinderNode> graph = new PathFinderGraph(_world.Height, _world.Width, _options.UseDiagonals);
+            var lowestNode = start;
+            var lowestNodeDist = int.MaxValue;
 
             var startNode = new PathFinderNode(position: start, g: 0, h: 2, parentNodePosition: start);
             graph.OpenNode(startNode);
@@ -62,6 +64,13 @@ namespace AStar
                     }
 
                     var newG = q.G + DistanceBetweenNodes;
+                    var distanceBetweenSuccessorAndEnd = this.CalculateDistance(q.Position, end);
+
+                    if (distanceBetweenSuccessorAndEnd < lowestNodeDist)
+                    {
+                        lowestNode = q.Position;
+                        lowestNodeDist = distanceBetweenSuccessorAndEnd;
+                    }
 
                     if (_options.PunishChangeDirection)
                     {
@@ -72,7 +81,7 @@ namespace AStar
                         {
                             if (qIsHorizontallyAdjacent)
                             {
-                                newG += Math.Abs(successor.Position.Row - end.Row) + Math.Abs(successor.Position.Column - end.Column);
+                                newG += this.CalculateDistance(successor.Position, end);
                             }
                         }
 
@@ -81,7 +90,7 @@ namespace AStar
                         {
                             if (!qIsHorizontallyAdjacent)
                             {
-                                newG += Math.Abs(successor.Position.Row - end.Row) + Math.Abs(successor.Position.Column - end.Column);
+                                newG += this.CalculateDistance(successor.Position, end);
                             }
                         }
                     }
@@ -101,7 +110,17 @@ namespace AStar
                 nodesVisited++;
             }
 
+            if (_options.ClosestNodeWhenCantReach && lowestNode != start)
+            {
+                return this.FindPath(start, lowestNode);
+            }
+
             return new Position[0];
+        }
+
+        private int CalculateDistance(Position currentNode, Position endNode)
+        {             
+            return Math.Abs(currentNode.Row - endNode.Row) + Math.Abs(currentNode.Column - endNode.Column);
         }
 
         private bool BetterPathToSuccessorFound(PathFinderNode updateSuccessor, PathFinderNode currentSuccessor)


### PR DESCRIPTION
Hi @valantonini, I must thank you for this pretty A* implementation. 

My pull request added a new option when the final node can't be reached. If this happens, a recursive call is made and the path returned is with the first closest node from the final node.

I don't know if this is the best and most optimized way to do it but works like a charm for me.

```
   var pathfinderOptions = new PathFinderOptions { 
      PunishChangeDirection = true,
      UseDiagonals = true, 
   };

   var tiles = new short[] {
      { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
      { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
   };

    var worldGrid = new WorldGrid(tiles)
    var pathfinder = new PathFinder(worldGrids, pathfinderOptions);
    
    // The following are equivalent:
    
    // matrix indexing
    Position[] path = pathfinder.FindPath(new Position(1, 4), new Position(4, 1));
```
![image](https://user-images.githubusercontent.com/5216299/131902234-57a36f1a-562e-4393-b89e-7d5e28dc78b2.png)

In this situation, the code returns 0 nodes, the unit can't walk from (1,4) to (4,1).


With this pull request this should happen:

```
   var pathfinderOptions = new PathFinderOptions { 
      PunishChangeDirection = true,
      UseDiagonals = true, 
      ClosestNodeWhenCantReach = true
   };

   var tiles = new short[] {
      { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
      { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 },
      { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
   };

    var worldGrid = new WorldGrid(tiles)
    var pathfinder = new PathFinder(worldGrids, pathfinderOptions);
    
    // The following are equivalent:
    
    // matrix indexing
    Position[] path = pathfinder.FindPath(new Position(1, 4), new Position(4, 1));
```

(1,4) -> (1,3) -> (2,2) -> (3,2) -> (4,2)

![image](https://user-images.githubusercontent.com/5216299/131903005-ed19038a-96d2-43cb-8099-50f898de3348.png)
